### PR TITLE
Import Default Group to allow Share Subscribed Groups

### DIFF
--- a/Controller/OptionsController.php
+++ b/Controller/OptionsController.php
@@ -132,11 +132,14 @@ class OptionsController extends AppController {
 
     $this->set('userId', $userId);
     $groups = $this->Group->find('all', array('conditions' => "Group.user_id = $userId", 'order' => array('Group.name' => 'ASC')));
+    $user = $this->User->findById($userId);
+    $groups = $this->Group->getGroupsForMedia($user);
     if ($groups) {
       $groups = Set::combine($groups, '{n}.Group.id', '{n}.Group.name');
     } else {
       $groups = array();
     }
+    sort($groups);
     $groups[-1] = __('[No Group]');
     $this->set('groups', $groups);
   }


### PR DESCRIPTION
I'm playing around with using phtagr for a family photo share site and i noticed that you can't set the Default Import Group to a group your are subscribed to.  I made these changes to allow that.  Let me know what you think.
